### PR TITLE
Simplify the Conditional Include Logic

### DIFF
--- a/third_party/nlcompiler/repo/nlcompiler.h
+++ b/third_party/nlcompiler/repo/nlcompiler.h
@@ -17,20 +17,16 @@
 #ifndef NLCOMPILER_H
 #define NLCOMPILER_H
 
-#if NL_SIMULATOR
-    #if defined(__GNUC__)
-        #if defined(__MACH__)
-            #if defined(__llvm__)
-                #include "llvm-macho/nlcompiler.h"
-            #else
-                #include "gcc-macho/nlcompiler.h"
-            #endif
-        #elif defined(__linux__)
-            #include "gcc-linux/nlcompiler.h"
+#if defined(__GNUC__)
+    #if defined(__MACH__)
+        #if defined(__llvm__)
+            #include "llvm-macho/nlcompiler.h"
+        #else
+            #include "gcc-macho/nlcompiler.h"
         #endif
-    #endif
-#else
-    #if defined(__GNUC__)
+    #elif defined(__linux__)
+        #include "gcc-linux/nlcompiler.h"
+    #else
         #if defined(__llvm__)
             #include "llvm-elf/nlcompiler.h"
         #else


### PR DESCRIPTION
Based on how symbols are asserted by host vs. target cross-compilers, the NL_SIMULATOR conditional is superfluous. Eliminate it and simply depend on prevailing symbols defined by the toolchain.